### PR TITLE
Added example configuration for embedded Artemis in JBoss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
 - mvn clean install
 - docker build -t jmstool-webspheremq -f docker/tomcat-websphereMQ/Dockerfile .
 - docker build -t jmstool-activemq -f docker/tomcat-activeMQ/Dockerfile .
+- docker build -t jmstool-artemismq -f docker/tomcat-artemisMQ/Dockerfile .
 cache:
   directories:
   - "$HOME/.m2/repository"
@@ -20,3 +21,5 @@ after_success:
 - docker push $DOCKER_USER/jmstool-webspheremq
 - docker tag jmstool-activemq:latest $DOCKER_USER/jmstool-activemq:latest
 - docker push $DOCKER_USER/jmstool-activemq
+- docker tag jmstool-artemismq:latest $DOCKER_USER/jmstool-artemismq:latest
+- docker push $DOCKER_USER/jmstool-artemismq

--- a/docker/tomcat-artemisMQ/Dockerfile
+++ b/docker/tomcat-artemisMQ/Dockerfile
@@ -1,0 +1,7 @@
+FROM tomcat:9-jre8
+
+RUN wget https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client-all/2.16.0/artemis-jms-client-all-2.16.0.jar -O lib/artemis-all.jar && \
+    wget https://repo1.maven.org/maven2/javax/jms/javax.jms-api/2.0/javax.jms-api-2.0.jar -O lib/jms-api.jar && \
+    rm -rf webapps/*
+
+COPY backend/target/jmstool.war webapps/ROOT.war

--- a/docker/tomcat-artemisMQ/context.xml
+++ b/docker/tomcat-artemisMQ/context.xml
@@ -1,0 +1,27 @@
+<Context>
+    <JarScanner scanClassPath="false" scanAllFiles="false" scanAllDirectories="false"/>
+
+  <Resource
+      user="dev"
+      password="pass4dev"
+      name="jms/QCF"
+      auth="Container"
+      type="org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"
+      factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory"
+	  brokerURL="tcp://artemismq:61616"/>
+
+   <Resource
+      name="jms/QDEV1"
+      auth="Container"
+      type="org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+      factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory"
+      address="jms.queue.DEV.QUEUE.1"/>
+
+   <Resource
+      name="jms/QDEV2"
+      auth="Container"
+      type="org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+      factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory"
+      address="jms.queue.DEV.QUEUE.2"/>
+
+</Context>

--- a/docker/tomcat-artemisMQ/docker-compose.yml
+++ b/docker/tomcat-artemisMQ/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  tomcat:
+    image: spx01/jmstool-artemismq:latest
+    container_name: jmstool-tomcat
+    ports:
+     - "8080:8080"
+    environment:
+     - TZ=Europe/Berlin
+     - spring.jms.jndi-name=java:comp/env/jms/QCF
+     - jmstool.incomingQueues=java:comp/env/jms/QDEV1
+     - jmstool.outgoingQueues=java:comp/env/jms/QDEV2
+    volumes:
+    - ./context.xml:/usr/local/tomcat/conf/context.xml
+  artemismq:
+    build: jboss
+    container_name: jmstool-artemismq
+    environment:
+      - PREPEND_JAVA_OPTS=-Djboss.server.default.config=standalone-full.xml
+    ports:
+     - "9990:9990"

--- a/docker/tomcat-artemisMQ/jboss/Dockerfile
+++ b/docker/tomcat-artemisMQ/jboss/Dockerfile
@@ -1,0 +1,4 @@
+FROM daggerok/jboss-eap-7.2
+
+ADD configure.cli /tmp/configure.cli
+RUN standalone.sh -Djboss.server.default.config=standalone-full.xml & (sleep 10 && add-user.sh -a -u dev -p pass4dev -g guest && add-user.sh -m -u admin -p admin && jboss-cli.sh --connect --file=/tmp/configure.cli)

--- a/docker/tomcat-artemisMQ/jboss/configure.cli
+++ b/docker/tomcat-artemisMQ/jboss/configure.cli
@@ -1,0 +1,13 @@
+connect
+
+/subsystem=messaging-activemq/server=default/jms-queue=DEV.QUEUE.1:add(entries=[java:jboss/exported/DEV.QUEUE.1])
+/subsystem=messaging-activemq/server=default/jms-queue=DEV.QUEUE.2:add(entries=[java:jboss/exported/DEV.QUEUE.2])
+
+reload
+
+/socket-binding-group=standard-sockets/socket-binding=activemq-5x:add(port=61616)
+
+reload
+
+/subsystem=messaging-activemq/server=default/remote-acceptor=activemq-5x-acceptor:add(socket-binding=activemq-5x)
+reload


### PR DESCRIPTION
I added a Dockerfile to build a Docker image of jmstool which can connect to embedded Artemis MQ in JBoss. Please have a look at the example described by the docker-compose.yml. 